### PR TITLE
chore: Add .gitignore to exclude system filesCreate .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# WordPress Core
+wp-config.php
+wp-content/uploads/
+wp-content/debug.log
+
+# IDE System Files
+.vscode/
+.idea/
+.DS_Store
+thumbs.db


### PR DESCRIPTION
### Description
Adds a standard `.gitignore` file to prevent sensitive files (like `wp-config.php`) and system junk (like `.DS_Store`) from being tracked in the repository.

### Changes
- Added `.gitignore` with standard WordPress exclusions.

### Type of Change
- [x] Chore (maintenance)